### PR TITLE
Configurable Execution Row Count

### DIFF
--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -18,3 +18,5 @@ AS_OF_DATE = 'NOW'
 # Time range to display. Data will be shown from AS_OF_DATE - HOUR_SPAN value to AS_OF_DATE.
 HOUR_SPAN = 360
 
+# How many of the past executions should we show on the dashboard?
+EXECUTION_COUNT=1000

--- a/dashboard/query/package-list.sql
+++ b/dashboard/query/package-list.sql
@@ -3,6 +3,7 @@ DECLARE @asOfDate DATETIME2 = NULLIF(?, 'NOW');
 DECLARE @folderNamePattern NVARCHAR(100) = ?;
 DECLARE @projectNamePattern NVARCHAR(100) = ?;
 DECLARE @statusFilter INT = ?;
+DECLARE @executionCount INT = ?;
 
 SET @asOfDate = ISNULL(@asOfDate, SYSDATETIME());
 
@@ -40,7 +41,7 @@ cteLoglevel as
 	where
 		parameter_name = 'LOGGING_LEVEL'
 )
-select top 15
+select top (@executionCount)
 	e.execution_id, 
 	e.project_name,
 	e.package_name,

--- a/dashboard/ssis.py
+++ b/dashboard/ssis.py
@@ -46,6 +46,7 @@ class monitor(object):
         self.config = configuration()
         self.config.hourSpan = app.config["HOUR_SPAN"]
         self.config.asOfDate = app.config["AS_OF_DATE"]
+        self.config.executionCount = app.config["EXECUTION_COUNT"]
         self.config.connectionString = app.config["CONNECTION_STRING"]["main"]
 
     def get_engine_info(self):
@@ -104,11 +105,12 @@ class monitor(object):
         result = self.__execute_query(
             'package-list.sql', 
             False,
-            self.config.hourSpan, 
-            self.config.asOfDate, 
-            self.__get_proper_name_filter(self.folder_name), 
-            self.__get_proper_name_filter(self.project_name), 
-            self.__get_proper_package_status_code(self.status)
+            self.config.hourSpan,
+            self.config.asOfDate,
+            self.__get_proper_name_filter(self.folder_name),
+            self.__get_proper_name_filter(self.project_name),
+            self.__get_proper_package_status_code(self.status),
+            self.config.executionCount
             )
 
         for r in result:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,7 +64,7 @@ flask run --host=0.0.0.0
 
 in this case the server will listen on port 5000 by default:
 ```
-http://locahost:5000/
+http://localhost:5000/
 ```
 
 for more information, like 
@@ -84,7 +84,7 @@ c:\<python-install-folder>\python.exe runserver.py
 ```
 now you can open your preferred browser and point to 
 ```
-http://locahost:5555/
+http://localhost:5555/
 ```
 and voilà, SSIS Dashboard running for you.
 


### PR DESCRIPTION
Right now the query is only grabbing the latest 15 executions.  This will allow you to configure the app to have a specific number of rows.